### PR TITLE
Adding monitoring role as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "playbooks/roles/monitoring"]
+	path = playbooks/roles/monitoring
+	url = git@github.com:tagiven/ansible-playbook-sensu.git

--- a/playbooks/main.yml
+++ b/playbooks/main.yml
@@ -33,3 +33,10 @@
   tags:
     - opscenter
 
+- name: "Install sensu monitoring agent"
+  hosts: dse-nodes
+  remote_user: root
+  roles:
+    - monitoring
+  tags:
+    - monitoring


### PR DESCRIPTION
Replacing prior commit and only adding code as submodule.  

Monitoring role code now lives in sub module fork.